### PR TITLE
Remove iot prefix from `iot_pkcs11`

### DIFF
--- a/iot_pkcs11_psa.c
+++ b/iot_pkcs11_psa.c
@@ -39,8 +39,8 @@
 #include "FreeRTOS.h"
 
 /* PKCS#11 includes. */
-#include "iot_pkcs11_config.h"
-#include "iot_pkcs11.h"
+#include "core_pkcs11_config.h"
+#include "core_pkcs11.h"
 #include "iot_pkcs11_psa_object_management.h"
 #include "iot_pkcs11_psa_input_format.h"
 

--- a/iot_pkcs11_psa_object_management.h
+++ b/iot_pkcs11_psa_object_management.h
@@ -33,8 +33,8 @@
 #include <stdbool.h>
 
 /* PKCS#11 includes. */
-#include "iot_pkcs11_config.h"
-#include "iot_pkcs11.h"
+#include "core_pkcs11_config.h"
+#include "core_pkcs11.h"
 
 /* PSA includes. */
 #include "psa/crypto.h"


### PR DESCRIPTION
As part of migrating PKCS to a separate repository, the naming scheme is being updated to remove the `iot` prefix.