### PR TITLE
.github/workflows/build: Run by cron schedule every day

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: freertos-pkcs11-psa CI
 on:
   push:
   pull_request:
+  schedule:
+  - cron: "0 4 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
As we're testing a submodule of bigger project here, it's not enough to
trigger CI on just changes to the submodule, as the build issues can
arise due to the changes in the main project. As we can't easily
track changes to the main project, just perform daily builds against
it.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>