### PR TITLE
Fix IAR compiling error

### DIFF
--- a/iot_pkcs11_psa.c
+++ b/iot_pkcs11_psa.c
@@ -2004,7 +2004,7 @@ CK_DEFINE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE xSession,
                             pxTemplate[ iAttrib ].ulValueLen = ulLength + 2;
                             *(( CK_BYTE *)(pxTemplate[ iAttrib ].pValue)) = 0x04;
                             *(( CK_BYTE *)(pxTemplate[ iAttrib ].pValue) + 1) = ulLength;
-                            memcpy( pxTemplate[ iAttrib ].pValue + 2, pxObjectValue, ulLength );
+                            memcpy( ( CK_BYTE *)(pxTemplate[ iAttrib ].pValue) + 2, pxObjectValue, ulLength );
                         }
                     }
 


### PR DESCRIPTION
Error[Pe852]: expression must be a pointer to a complete object type

Signed-off-by: Charley Chu <haoc@cypress.com>