### PR TITLE
.github/workflows/build.yml: Pin OS to ubuntu-20.04.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build cypress/CY8CKIT_064S0S2_4343W
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Clone
       uses: actions/checkout@v1


### PR DESCRIPTION
Before this change, we effectively used ubuntu-18.04.

The specific situation which prompts this change is that Python
"cryptography" package got a major internal upgrade to use Rust code.
At the same time, its binary (.whl) packages were upgraded to modern
version, which cannot be installed with (pretty old by now) "pip3"
version shipped with Ubuntu 18.04.

Finally, "ubuntu-latest" (as used now) is anyway scheduled to be
switched to ubuntu-20.04, so we're just taking steps ahead, and
follow the best practice to pin (system-level) dependencies.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>