### PR TITLE
 mbedtls: Adapt to release v3.6.0 changes

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -11,7 +11,7 @@ For example, objective storage and signing.
 The original PKCS#11 API implementation in Amazon FreeRTOS is based on [mbedTLS](https://github.com/ARMmbed/mbedtls).
 This project is the PSA based PKCS#11 API implementation. This is done by adding the shim layer between these two API sets.
 
-In general, this shim layer maps the PKCS#11 APIs to PSA Cryptography and Storage APIs V1.0. It follows the same PSA Cryptography API version supported in [mbedtls-3.4.0](https://github.com/ARMmbed/mbedtls/tree/mbedtls-3.4.0). Certificate objects and key objects are protected by PSA secure service. By default, the device private/public keys are persistent while the code verify key is volatile.
+In general, this shim layer maps the PKCS#11 APIs to PSA Cryptography and Storage APIs V1.0. It follows the same PSA Cryptography API version supported in [mbedtls-3.6.0](https://github.com/ARMmbed/mbedtls/tree/mbedtls-3.6.0). Certificate objects and key objects are protected by PSA secure service. By default, the device private/public keys are persistent while the code verify key is volatile.
 
 # License
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -41,7 +41,7 @@ In Amazon FreeRTOS, this shim layer is cloned into `libraries/abstractions/pkcs1
 
 [TF-M](https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/) is a PSA implementation. It implements the PSA Firmware Framework API and developer API such as Secure Storage, Cryptography, Initial Attestation, etc. Refer to [PSA website](https://developer.arm.com/architectures/security-architectures/platform-security-architecture) for more details.
 
-This version of PKCS#11 shim layer is supported by [TF-M v1.8.0](https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tag/?h=TF-Mv1.8.0).
+This version of PKCS#11 shim layer is supported by [TF-M v2.1.0](https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tag/?h=TF-Mv2.1.0).
 
 Please follow the [Build instructions](https://tf-m-user-guide.trustedfirmware.org/docs/technical_references/instructions/tfm_build_instruction.html) of TF-M to build the secure side image for your platform.
 

--- a/iot_pkcs11_psa.c
+++ b/iot_pkcs11_psa.c
@@ -38,6 +38,8 @@
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
+
 /* PKCS#11 includes. */
 #include "core_pkcs11_config.h"
 #include "core_pkcs11.h"
@@ -46,7 +48,6 @@
 
 /* mbedTLS includes. */
 #include "mbedtls/pk.h"
-#include "mbedtls/pk_internal.h"
 
 #define PKCS11_PRINT( X )            vLoggingPrintf X
 #define PKCS11_WARNING_PRINT( X )    /* vLoggingPrintf  X */
@@ -646,7 +647,7 @@ CK_RV prvCreateRsaPrivateKey( mbedtls_pk_context * pxMbedContext,
     *ppxLabel = NULL;
     *ppxClass = NULL;
     pxRsaContext = pxMbedContext->pk_ctx;
-    mbedtls_rsa_init( pxRsaContext, MBEDTLS_RSA_PKCS_V15, 0 /*ignored.*/ );
+    mbedtls_rsa_init( pxRsaContext );
 
     /* Parse template and collect the relevant parts. */
     for( ulIndex = 0; ulIndex < ulCount; ulIndex++ )
@@ -819,7 +820,7 @@ CK_RV prvCreatePrivateKey( CK_ATTRIBUTE_PTR pxTemplate,
         if( pxRsaCtx != NULL )
         {
             xMbedContext.pk_ctx = pxRsaCtx;
-            xMbedContext.pk_info = &mbedtls_rsa_info;
+            xMbedContext.pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_RSA);
             xResult = prvCreateRsaPrivateKey( &xMbedContext,
                                               &pxLabel,
                                               &pxClass,
@@ -851,7 +852,7 @@ CK_RV prvCreatePrivateKey( CK_ATTRIBUTE_PTR pxTemplate,
             if( pxKeyPair != NULL )
             {
                 /* Initialize the info. */
-                xMbedContext.pk_info = &mbedtls_eckey_info;
+                xMbedContext.pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY);
 
                 /* Initialize the context. */
                 xMbedContext.pk_ctx = pxKeyPair;
@@ -1082,7 +1083,7 @@ CK_RV prvCreatePublicKey( CK_ATTRIBUTE_PTR pxTemplate,
             if( pxKeyPair != NULL )
             {
                 /* Initialize the info. */
-                xMbedContext.pk_info = &mbedtls_eckey_info;
+                xMbedContext.pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY);;
 
                 /* Initialize the context. */
                 xMbedContext.pk_ctx = pxKeyPair;

--- a/iot_pkcs11_psa_input_format.h
+++ b/iot_pkcs11_psa_input_format.h
@@ -27,7 +27,6 @@
 /* mbedTLS includes. */
 #include "mbedtls/pk.h"
 #include "mbedtls/asn1.h"
-#include "mbedtls/pk_internal.h"
 #include "mbedtls/oid.h"
 
 #define pkcs11DER_ENCODED_OID_P256_LEGNTH    19

--- a/iot_pkcs11_psa_object_management.c
+++ b/iot_pkcs11_psa_object_management.c
@@ -32,6 +32,9 @@
  */
 
 #include <string.h>
+
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
+
 #include "iot_pkcs11_psa_object_management.h"
 #include "iot_pkcs11_psa_input_format.h"
 


### PR DESCRIPTION
This PR introduce the following changes:

* Add #define MBEDTLS_ALLOW_PRIVATE_ACCESS to every file that access private struct members.
* Remove mbedtls/pk_internal.h header file inclusion, because it no longer exists in the latest mbedtls version.
* Direct access to pk_info structs has been removed, mbedtls_pk_info_from_type function should be used.
* mbedtls_rsa_init function prototype has been changed, newer prototype should be used.