### PR TITLE
Fix a memory leak in C_FindObjects

### DIFF
--- a/iot_pkcs11_psa.c
+++ b/iot_pkcs11_psa.c
@@ -2439,6 +2439,16 @@ CK_DECLARE_FUNCTION( CK_RV, C_FindObjects )( CK_SESSION_HANDLE xSession,
         }
     }
 
+    /* Clean up memory if there was an error finding the object. */
+    if( xResult != CKR_OK )
+    {
+        if( pxSession != NULL && pxSession->pxFindObjectLabel != NULL)
+        {
+            vPortFree( pxSession->pxFindObjectLabel );
+            pxSession->pxFindObjectLabel = NULL;
+        }
+    }
+
     return xResult;
 }
 

--- a/iot_pkcs11_psa.c
+++ b/iot_pkcs11_psa.c
@@ -2173,7 +2173,7 @@ static CK_RV  FindKeyObjects ( P11SessionPtr_t pxSession,
             /* Import the key into the PKCS#11 context. */
             PKCS11PSAContextImportObject( pxSession->pxFindObjectLabel,
                                           strlen( ( const char * ) pxSession->pxFindObjectLabel ),
-                                          uxPsaDeviceKeyHandle );
+                                          xKeyId );
         }
 #ifndef pkcs11configTFM_VERSION_1_0
         else if ( uxStatus != PSA_ERROR_INVALID_HANDLE )


### PR DESCRIPTION
* pkcs11: Fix a memory leak in C_FindObjects
    * The [corePKCS11](https://github.com/FreeRTOS/corePKCS11/blob/main/source/core_pkcs11.c) expects that allocated memory is freed by the API `C_FindObjects` in the case of error in finding the requested object. This expectation was not met, which led to a memory leak when finding the requested object fails. Release the allocated memory, if returning an error from `C_FindObjects`.
* pkcs11: Use key ID instead of key handle
    * The hey handle is not supported by Mbed TLS 3.6.0 anymore, therefore use key ID instead.